### PR TITLE
Add haxelib.json

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -4,8 +4,8 @@
   "license": "MIT",
   "tags": [ ],
   "description": "as3hx is a utility to help automatically convert ActionScript source code into compatible Haxe code",
-  "version": "1.0.0",
-  "releasenote": "Initial haxelib release",
+  "version": "1.0.1",
+  "releasenote": "Parser improvement",
   "contributors": [ "singmajesty" ],
   "dependencies": {}
 }

--- a/haxelib.json
+++ b/haxelib.json
@@ -1,0 +1,11 @@
+{
+  "name": "as3hx",
+  "url": "http://github.com/HaxeFoundation/as3hx",
+  "license": "MIT",
+  "tags": [ ],
+  "description": "as3hx is a utility to help automatically convert ActionScript source code into compatible Haxe code",
+  "version": "1.0.0",
+  "releasenote": "Initial haxelib release",
+  "contributors": [ "singmajesty" ],
+  "dependencies": {}
+}


### PR DESCRIPTION
These commits add a haxelib.json file, currently what is used on http://lib.haxe.org/p/as3hx

Of course, the "contributors" array could include anyone else from the Haxe Foundation that would like to help keep the haxelib release up-to-date as well. By making it available on haxelib, it enables the following workflow:

    haxelib install as3hx
    haxelib run as3hx path/to/as path/to/output

I think this is a good way to use the library