### PR TITLE
Call `StringTools.trim(string)` instead of `mx.utils.StringUtil.trim(string)`. closes #213

### DIFF
--- a/src/as3hx/Writer.hx
+++ b/src/as3hx/Writer.hx
@@ -2733,18 +2733,19 @@ class Writer
                         result = EArray(ECall(EField(e, "splice"), params), EConst(CInt("0")));
                     }
                 }
-                else {
-                    var ident = getIdentString(e);
-                    if (ident != null) {
-                        //replace AS3 StringUtil by Haxe StringTools
-                        if (ident == "StringUtil") {
-                            var rebuiltExpr = EField(EIdent("StringTools"), f);
-                            result = ECall(rebuiltExpr, params);
-                        } else if (ident == "JSON") {
-                            var rebuiltExpr = EField(EIdent("haxe.Json"), f);
-                            result = ECall(rebuiltExpr, params);
-                        }
+                else if(f == "trim") {
+                    if(getIdentString(e) == "StringUtil") {
+                        result = ECall(EField(EIdent("StringTools"), f), params);
                     }
+                }
+                else if(f == "isWhitespace") {
+                    if(getIdentString(e) == "StringUtil") {
+                        params.push(EConst(CInt("0")));
+                        result = ECall(EField(EIdent("StringTools"), "isSpace"), params);
+                    }
+                }
+                else if(getIdentString(e) == "JSON") {
+                    result = ECall(EField(EIdent("haxe.Json"), f), params);
                 }
             case EParent(e):
                 result = switch(fullExpr) {

--- a/src/as3hx/parsers/ImportParser.hx
+++ b/src/as3hx/parsers/ImportParser.hx
@@ -19,35 +19,41 @@ class ImportParser {
     public static function parse(tokenizer:Tokenizer, cfg:Config) {
         Debug.dbg("parseImport()", tokenizer.line);
         var a = [tokenizer.id()];
-        while( true ) {
+        while(true) {
             var tk = tokenizer.token();
-            switch( tk ) {
-            case TDot:
-                tk = tokenizer.token();
-                switch(tk) {
-                case TId(id):
-                    if (Lambda.has(doNotImport, id)) return [];
-                    // TODO: this is flash.utils.Proxy need to create a compat class
-                    // http://blog.int3ractive.com/2010/05/using-flash-proxy-class.html
-                    if (id == "flash_proxy") return ["flash","utils","Proxy"];
-                    // import __AS3__.vec.Vector;
-                    if (id == "Vector" && a[0] == "__AS3__") return [];
-                    // import flash.utils.Dictionary;
-                    if (cfg.dictionaryToHash && id == "Dictionary" && a.length == 2 && a[0] == "flash" && a[1] == "utils") return [];
-                    a.push(id);
-                case TOp(op):
-                    if(op == "*") {
-                        a.push(op);
-                        break;
+            switch(tk) {
+                case TDot:
+                    tk = tokenizer.token();
+                    switch(tk) {
+                        case TId(id):
+                            if (Lambda.has(doNotImport, id)) return [];
+                            // TODO: this is flash.utils.Proxy need to create a compat class
+                            // http://blog.int3ractive.com/2010/05/using-flash-proxy-class.html
+                            if (id == "flash_proxy") return ["flash","utils","Proxy"];
+                            // import __AS3__.vec.Vector;
+                            if (id == "Vector" && a[0] == "__AS3__") return [];
+                            // import flash.utils.Dictionary;
+                            if (cfg.dictionaryToHash && id == "Dictionary" && a.length == 2 && a[0] == "flash" && a[1] == "utils") return [];
+                            if (id == "StringUtil") {
+                                switch(a) {
+                                    case ["mx", "utils"]: return [];
+                                    default:
+                                }
+                            }
+                            a.push(id);
+                        case TOp(op):
+                            if(op == "*") {
+                                a.push(op);
+                                break;
+                            }
+                            ParserUtils.unexpected(tk);
+                        default: ParserUtils.unexpected(tk);
                     }
-                    ParserUtils.unexpected(tk);
-                default: ParserUtils.unexpected(tk);
-                }
-            case TCommented(s,b,t):
-                tokenizer.add(t);
-            default:
-                tokenizer.add(tk);
-                break;
+                case TCommented(s,b,t):
+                    tokenizer.add(t);
+                default:
+                    tokenizer.add(tk);
+                    break;
             }
         }
         Debug.dbgln(" -> " + a, tokenizer.line);

--- a/test/issues/Issue213.as
+++ b/test/issues/Issue213.as
@@ -1,0 +1,16 @@
+package {
+    import starling.utils.StringUtil;
+    public class Issue213 {
+        public function Issue213() {
+            StringUtil.format("[VertexData format=\"{0}\" numVertices={1}]", "", 1);
+        }
+    }
+}
+
+import mx.utils.StringUtil;
+class Foo {
+    public function Foo() {
+        StringUtil.trim(" abc ");
+        StringUtil.isWhitespace("");
+    }
+}

--- a/test/issues/Issue213.hx
+++ b/test/issues/Issue213.hx
@@ -1,0 +1,20 @@
+import starling.utils.StringUtil;
+
+class Issue213
+{
+    public function new()
+    {
+        StringUtil.format("[VertexData format=\"{0}\" numVertices={1}]", "", 1);
+    }
+}
+
+
+
+class Foo
+{
+    public function new()
+    {
+        StringTools.trim(" abc ");
+        StringTools.isSpace("", 0);
+    }
+}

--- a/test/unit/as3hx/AS3HXTest.hx
+++ b/test/unit/as3hx/AS3HXTest.hx
@@ -378,6 +378,11 @@ class AS3HXTest {
         generate("Issue210.as", "Issue210.hx");
     }
     
+    @Test
+    public function issue213() {
+        generate("Issue213.as", "Issue213.hx");
+    }
+    
     @Test("string.replace(regex, by) -> regex.replace(string, by)")
     public function issue215() {
         generate("Issue215.as", "Issue215.hx");


### PR DESCRIPTION
Call `StringTools.isSpace(string, 0)` instead of `mx.utils.StringUtil.isWhitespace(string)`