### PR TITLE
modify haxelib.json to include src as classpath

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -5,6 +5,7 @@
   "tags": [ ],
   "description": "as3hx is a utility to help automatically convert ActionScript source code into compatible Haxe code",
   "version": "1.0.4",
+  "classPath": "src",
   "releasenote": "Parser fixes",
   "contributors": [ "singmajesty", "slavara" ],
   "dependencies": {}


### PR DESCRIPTION
Adds a classpath line to `haxelib.json`.
This change makes the lib able to be batch imported in IDEA and makes imports work for those that want to use e.g. as3hx.Compat in their haxe project.