### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,7 @@
  - Replace `Number.NEGATIVE_INFINITY` with `Math.NEGATIVE_INFINITY`
  - Replace `Number.POSITIVE_INFINITY` with `Math.POSITIVE_INFINITY`
 
-##2016-08-24(1.0.4)
+## 2016-08-24(1.0.4)
  - Fixed conversion of unary operator after declaration of block
  - Fixed convesion `of if(number)`
  - Fixed conversion of `array.join("\n")`
@@ -52,7 +52,7 @@
  - Loops will be converted to `while` instead of `for` for proper iteration variable modification
  - Only first character of package will be transformed to lower case
  
-##2016-08-05(1.0.3)
+## 2016-08-05(1.0.3)
  - Fixed call for `haxe.Json.parse` instead of `JSON.parse` (closes issue #83)
  - Fixed casting of `uint(1)` (closes issue #85)
  - Fixed conversion of [String.]charAt() with zero args (closes issue #69)
@@ -83,10 +83,10 @@
  - Replace `array.slice()` with `array.copy()` (closes issue #68)
  - Replace `NaN` with `Math.NaN` (closes issue #89)
 
-##2013-10-28 - Scott Lee
+## 2013-10-28 - Scott Lee
  - Move to Haxe 3 and neko 2
 
-##2013-08-01 - Yanhick, Richard, Todd
+## 2013-08-01 - Yanhick, Richard, Todd
  - added many improvements to generated code style
  - replaced as3 "toString" by Haxe "Std.string"
  - replaced as3 "Date" by Haxe "Date.now" for current time
@@ -111,7 +111,7 @@
  - Removed conversion of escape sequences in Parser.readString
  - Added odd as3 vector constructor style: mStringVec = new <String>["a","b"];
 
-##2011-10-19 - Russell
+## 2011-10-19 - Russell
  - Added writing out class inits
  - Fixed empty functions returning f.expr = Object (messed up metadata parsing)
  - Improved metadata support for [Bindable("move")]
@@ -132,12 +132,12 @@
  - Skip comments in object create or fuction calls
  - Support for Vector added to Writer
 
-##2011-10-14 - Russell
+## 2011-10-14 - Russell
  - cleaned formatting on comments
  - added === support (missed)
  - added -no-cast-guess 
 
-##2011-10-12 - Russell
+## 2011-10-12 - Russell
  - added comments
  - fixed static var initializations were not output
  - added output for the "as" keyword

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-#as3hx [![Build Status](https://travis-ci.org/HaxeFoundation/as3hx.svg?branch=master)](https://travis-ci.org/HaxeFoundation/as3hx)
+# as3hx [![Build Status](https://travis-ci.org/HaxeFoundation/as3hx.svg?branch=master)](https://travis-ci.org/HaxeFoundation/as3hx)
 Convert ActionScript 3 to Haxe 3 code.
 
-###Build
+### Build
 You'll need Haxe 3.* to build the project and Neko 2.* to run it.
     
     haxe --no-traces as3hx.hxml
@@ -10,7 +10,7 @@ Build the as3hx tool.
     haxe -debug as3hx.hxml
 Build with debug output when converting files.
 
-###Use
+### Use
 
     neko run.n test/ out/
     
@@ -27,7 +27,7 @@ To get the basic tool usage :
 
     neko run.n -help
 
-###Config
+### Config
 
 There are many configuration options to choose how the Haxe code
 is generated, check the src/as3hx/Config.hx file for the full list.
@@ -37,15 +37,15 @@ called ".as3hx_config.xml". You can also create one in the directory
 you are running as3hx from, which will override the home file.
 
 
-####Licence
+#### Licence
 
 MIT, see [LICENCE.md](LICENCE.md)
 
 
 
-###Current failures:
+### Current failures:
 
-####'delete' keyword:
+#### 'delete' keyword:
 In ActionScript, the `delete` keyword will cause an intentional failure in the
 generated .hx file. Take a close look at the object being deleted.
 
@@ -57,11 +57,11 @@ Senocular did a little writeup on `delete` that might make it more clear
 http://www.kirupa.com/forum/showthread.php?223798-ActionScript-3-Tip-of-the-Day/page3
 
 
-####E4X:
+#### E4X:
 E4X is currently partly done. This will fail in some cases, just examine source
 and output carefully.
 
-####For Initializations:
+#### For Initializations:
 The output of
 
 ```as3


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
