### PR TITLE
fixes #264. fixes #277

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
  - Fixed conversion of `private const FOO : int = 1;`. fixes #255
  - Fixed conversion of `if(true) return\n`. fixes #254
  - Fixed conversion of `SomeClass['staticFieldName']`. fixes #234
+ - Fixed conversion of `else if` blocks. fixes #277
+ - Fixed conversion of comments before `else` blocks. fixes #264
  - Replace `navigateToURL` with `flash.Lib.getURL`. fixes #257
  - Replace `static var init = {...}` by `static var ClassName_static_initializer = {...}`. fixes #276
 

--- a/src/as3hx/Writer.hx
+++ b/src/as3hx/Writer.hx
@@ -126,6 +126,12 @@ class Writer
                         if (i == 0) f(ex[0]);
                         else result.push(ex[i]);
                     }
+                case ECommented(s,b,t,e):
+                    // issue 264
+                    // catch comments before else blocks
+                    writeNL();
+                    writeIndent(s);
+                    result.push(ENL(e));
                 case ENL(ex): f(ex);
                 case EObject(fl) if(fl.empty()):
                 default: result.push(ENL(e));
@@ -1838,6 +1844,11 @@ class Writer
                                         // the `if` statement instead so we stay on
                                         // the same line as the `else` -> `else if`
                                         elseif = e4;
+                                    case EBlock(_):
+                                        // issue 264
+                                        // catch double-nested blocks and replace
+                                        // outer block with inner block
+                                        e2 = e4;
                                     default:
                                 }
                             default:

--- a/src/as3hx/Writer.hx
+++ b/src/as3hx/Writer.hx
@@ -127,7 +127,6 @@ class Writer
                         else result.push(ex[i]);
                     }
                 case ECommented(s,b,t,e):
-                    // issue 264
                     // catch comments before else blocks
                     writeNL();
                     writeIndent(s);
@@ -664,7 +663,7 @@ class Writer
                 }
                 break;
             }
-            else if (field == f){
+            else if (field == f) {
                 foundSelf = true;
             }
         } 
@@ -802,7 +801,7 @@ class Writer
                         pendingComma = true;
 
                     case ENL(e): //newline
-                        if (pendingComma){
+                        if (pendingComma) {
                             pendingComma = false;
                             write(",");
                         }
@@ -810,7 +809,7 @@ class Writer
                         writeIndent();
 
                     case ECommented(s,b,t,e): // comment among arguments
-                        if (pendingComma){
+                        if (pendingComma) {
                             pendingComma = false;
                             write(",");
                         }
@@ -1828,13 +1827,12 @@ class Writer
             e2 = EBlock(formatBlockBody(e2));
             writeNL();
             var elseif:Expr = null;
-            // issue 277
             // if we find an EBlock([ENL(EIf(...))])
             // after an `else` then we have an
             // `else if` statement
             switch(e2) {
                 case EBlock(e3):
-                    if(e3 != null && e3.length == 1) {
+                    if (e3 != null && e3.length == 1) {
                         switch(e3[0]) {
                             case ENL(e4):
                                 switch(e4) {
@@ -1845,7 +1843,6 @@ class Writer
                                         // the same line as the `else` -> `else if`
                                         elseif = e4;
                                     case EBlock(_):
-                                        // issue 264
                                         // catch double-nested blocks and replace
                                         // outer block with inner block
                                         e2 = e4;
@@ -1858,10 +1855,10 @@ class Writer
                     elseif = e2;
                 default:
             }
-            if(elseif != null) {
+            if (elseif != null) {
                 writeIndent("else ");
                 result = writeExpr(elseif);
-            }else{
+            } else {
                 writeIndent("else");
                 writeStartStatement();
                 result = writeExpr(e2);

--- a/test/issues/Issue264.as
+++ b/test/issues/Issue264.as
@@ -1,0 +1,23 @@
+package {
+  public class Issue264 {
+    public function Issue264() {
+      
+      var obj:Object = new Object();
+      var message:String;
+      
+      // error inside
+      if (obj.error is Error) {
+        message = obj.error.message;
+      }
+      // error event inside
+      else if (obj.error is ErrorEvent) {
+        message = obj.error.text;
+      }
+      // unknown
+      else {
+        message = obj.error.toString();
+      }
+      
+    }
+  }
+}

--- a/test/issues/Issue264.hx
+++ b/test/issues/Issue264.hx
@@ -1,0 +1,25 @@
+
+class Issue264
+{
+    public function new()
+    {
+        var obj : Dynamic = {};
+        var message : String;
+        
+        // error inside
+        if (Std.is(obj.error, Error))
+        {
+            message = obj.error.message;
+        }
+        // error event inside
+        else if (Std.is(obj.error, ErrorEvent))
+        {
+            message = obj.error.text;
+        }
+        // unknown
+        else
+        {
+            message = Std.string(obj.error);
+        }
+    }
+}

--- a/test/issues/Issue277.as
+++ b/test/issues/Issue277.as
@@ -1,0 +1,29 @@
+package {
+    public class Issue277 {
+        public function Issue277() {
+            if(1) {
+            	a();
+            }else if(2) {
+            	b();
+            }else if(3) {
+                c();
+            }else if(4) {
+                d();
+            }else if(5) {
+                e();
+            }else if(6) {
+                f();
+            }else if(7) {
+                g();
+            }else if(8) {
+                h();
+            }else if(9) {
+                i();
+            }else if(10) {
+                j();
+            }else{
+                k();
+            }
+        }
+    }
+}

--- a/test/issues/Issue277.hx
+++ b/test/issues/Issue277.hx
@@ -1,0 +1,51 @@
+
+class Issue277
+{
+    public function new()
+    {
+        if (1)
+        {
+            a();
+        }
+        else if (2)
+        {
+            b();
+        }
+        else if (3)
+        {
+            c();
+        }
+        else if (4)
+        {
+            d();
+        }
+        else if (5)
+        {
+            e();
+        }
+        else if (6)
+        {
+            f();
+        }
+        else if (7)
+        {
+            g();
+        }
+        else if (8)
+        {
+            h();
+        }
+        else if (9)
+        {
+            i();
+        }
+        else if (10)
+        {
+            j();
+        }
+        else
+        {
+            k();
+        }
+    }
+}


### PR DESCRIPTION
- keeps `else if` statements in one line
- handles comments between conditional blocks
- removes double-nested blocks